### PR TITLE
Add eslint-config-wix to devDeps.

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "babel-preset-env": "^1.5.2",
     "babel-preset-stage-3": "^6.5.0",
     "chai": "^3.5.0",
+    "eslint-config-wix": "^1.1.0",
     "husky": "^0.13.4",
     "yoshi": "latest"
   },


### PR DESCRIPTION
This PR should fix [CI build](http://tc.dev.wixpress.com/viewLog.html?buildId=65169522&buildTypeId=ImportPath_ImportPath) since `eslint-config-wix` is no longer a yoshi dependency.