### PR TITLE
Only emit .d.ts files if a src/**/.d.ts file exists

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
   },
   "dependencies": {
     "@phenomnomnominal/tsquery": "^3.0.0",
-    "babel-runtime": "^6.22.0"
+    "babel-runtime": "^6.22.0",
+    "typescript": "~3.2.4"
   },
   "devDependencies": {
     "babel-plugin-transform-runtime": "^6.22.0",

--- a/package.json
+++ b/package.json
@@ -47,8 +47,7 @@
   },
   "dependencies": {
     "@phenomnomnominal/tsquery": "^3.0.0",
-    "babel-runtime": "^6.22.0",
-    "typescript": "~3.2.4"
+    "babel-runtime": "^6.22.0"
   },
   "devDependencies": {
     "babel-plugin-transform-runtime": "^6.22.0",
@@ -57,7 +56,11 @@
     "chai": "^3.5.0",
     "eslint-config-wix": "^1.1.0",
     "husky": "^0.13.4",
+    "typescript": "~3.2.4",
     "yoshi": "latest"
+  },
+  "peerDependencies": {
+    "typescript": "^3.2.4"
   },
   "babel": {
     "presets": [

--- a/src/scan.js
+++ b/src/scan.js
@@ -48,11 +48,10 @@ module.exports = function (pathName, dts, options = {}) {
           {path: `./${name}.js`, source: `module.exports = require('./${componentPath}');\n`},
         ];
 
-        if (dts) {
+        if (dts && hasDtsFile(componentPath)) {
           const codeLines = [`export * from './${componentPath}';`];
 
-          if (hasDtsFile(componentPath) &&
-            hasDefaultExport(componentPath)) {
+          if (hasDefaultExport(componentPath)) {
             codeLines.push(`import defaultExport from './${componentPath}';`);
             codeLines.push('export default defaultExport;');
           }


### PR DESCRIPTION
This will "change" existing behavior in all consuming projects - without no expected side-effects.
We think this is actually desired in all of them as well.

Currently - if the `--dts` option is given - we always emit a `.d.ts` file in the root path, even if it doesn't point to a deeper `.d.ts` file and only sources exist (which is the case in WSR with components that aren't typed yet), although this should only happen in WSR since it's the only consuming project that uses `--dts` that isn't a TypeScript project itself (which means the only one that is partially typed).
