### PR TITLE
upgrade `commander` and add it to dependencies

### DIFF
--- a/import-path.js
+++ b/import-path.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-const program = require('commander');
+const {program} = require('commander');
 
 program
   .version('0.0.1')
@@ -8,4 +8,6 @@ program
   .option('--dts', 'Create typescript declaration files')
   .parse(process.argv);
 
-require('./src/scan')(program.path, program.dts);
+const options = program.opts();
+
+require('./src/scan')(options.path, options.dts);

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "eslint-config-wix": "^1.1.0",
     "husky": "^0.13.4",
     "typescript": "~3.2.4",
-    "yoshi": "latest"
+    "yoshi": "4.5.0"
   },
   "peerDependencies": {
     "typescript": "^3.2.4"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": false,
   "name": "import-path",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "This package will allow users to require your package without writing dist/src",
   "author": {
     "name": "Lior Belinsky",
@@ -47,7 +47,8 @@
   },
   "dependencies": {
     "@phenomnomnominal/tsquery": "^3.0.0",
-    "babel-runtime": "^6.22.0"
+    "babel-runtime": "^6.22.0",
+    "commander": "^8.2.0"
   },
   "devDependencies": {
     "babel-plugin-transform-runtime": "^6.22.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": false,
   "name": "import-path",
-  "version": "2.0.0",
+  "version": "1.0.0",
   "description": "This package will allow users to require your package without writing dist/src",
   "author": {
     "name": "Lior Belinsky",


### PR DESCRIPTION
This PR does a few things:

1. add `commander` to `dependencies` of `package.json`.
   This is needed, because without it `import-path` can fail in projects
   that don't have `commander` in their `node_modules`. So `commander`
   was improperly treated like a `peerDependency`

2. upgrade commander to `8.2.0`
   This is needed, because `import-path` relied on old `commander`
   version. Given that `commander` was not set as dependency, projects
   using `import-path` not only have to provide `commander` but also
   provide an old version of it. More up-to-date projects that use more
   recent `commander` versions need to keep two `commander` versions in
   their `node_modules`.

3. set `yoshi` to `4.5.0`
   needed, because previously used `latest` bring yoshi version which is
   no longer compatible with this project

